### PR TITLE
adds repository details in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "slate-irc-sasl",
   "version": "1.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hagb4rd/slate-irc-sasl.git"
+  },
   "description": "Node.js IRC client library plugin for EXTERNAL SASL AUTHENTIFICATION",
   "keywords": [
     "irc",


### PR DESCRIPTION
Providing git repository details in the package.json would add a hyperlink in npm package page for easily navigating from npm website to the source control page (github in this case).

![image](https://user-images.githubusercontent.com/4211715/52931208-94116600-3371-11e9-9d15-64987ac7ad38.png)
